### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-lint-check.yml
+++ b/.github/workflows/run-lint-check.yml
@@ -1,5 +1,8 @@
 name: Check for print/console.log statements
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ master ]
@@ -7,4 +10,3 @@ on:
 jobs:
   call-lint-check:
     uses: Skill-Forge-Project/ci-templates/.github/workflows/lint-check.yml@master
-


### PR DESCRIPTION
Potential fix for [https://github.com/Skill-Forge-Project/skill_forge_auth/security/code-scanning/3](https://github.com/Skill-Forge-Project/skill_forge_auth/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the context, the workflow likely only needs read access to the repository contents. If additional permissions are required, they can be added later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
